### PR TITLE
Fix misinformation

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -124,11 +124,14 @@ An **action** is the combination of controller inputs the bot presses (throttle,
 
 Most bots use a **discrete action** parser, which separates every useful permutation of inputs into their own box, and the bot can control the car by picking a specific box of inputs.
 
-Now before you go ahead and swap out `ContinuousAction` with `DiscreteAction`, beware:
-`DiscreteAction` is actually `MultiDiscrete`, which is not what I described.
-The fully-discrete[*] action parser is called `LookupAction`, and is not included by the library by default.
-
+Beware: The fully-discrete[*] action parser is called `LookupAction`, and is not included by the library by default. 
 You can find it here: https://github.com/RLGym/rlgym-tools/blob/main/rlgym_tools/extra_action_parsers/lookup_act.py
+
+Now before you go changing your `ContinuousAction()` into `DiscreteAction()`, you should import `DiscreteAction` by entering this:
+```python
+from rlgym_sim.utils.action_parsers import DiscreteAction``
+```
+and don't forget to change your ``action_parser = DiscreteAction()`` into a ``action_parser = DiscreteAction()``
 
 Since action parsers define how your bot controls the car, changing it usually means resetting the bot.
 

--- a/intro.md
+++ b/intro.md
@@ -129,7 +129,7 @@ You can find it here: https://github.com/RLGym/rlgym-tools/blob/main/rlgym_tools
 
 Now before you go changing your `ContinuousAction()` into `DiscreteAction()`, you should import `DiscreteAction` by entering this:
 ```python
-from rlgym_sim.utils.action_parsers import DiscreteAction``
+from rlgym_sim.utils.action_parsers import DiscreteAction
 ```
 and don't forget to change your ``action_parser = DiscreteAction()`` into a ``action_parser = DiscreteAction()``
 


### PR DESCRIPTION
I just noticed that MultiDiscrete would throw you errors if you actually imported it and used, because the __init__.py of the action parser folder names the discrete setting into "DiscreteAction", not "MultiDiscrete"